### PR TITLE
Fix React version mismatch in importmap

### DIFF
--- a/react/example/index.html
+++ b/react/example/index.html
@@ -8,8 +8,9 @@
     <script type="importmap">
       {
         "imports": {
-          "react": "https://esm.sh/react@18.3.1",
-          "react-dom": "https://esm.sh/react-dom@18.3.1"
+          "react": "https://esm.sh/react@19",
+          "react-dom": "https://esm.sh/react-dom@19",
+          "react-dom/client": "https://esm.sh/react-dom@19/client"
         }
       }
     </script>


### PR DESCRIPTION
Update importmap to use React 19 to match package.json. The previous version (18.3.1) caused runtime errors.