### PR TITLE
Allow flipping during running flips

### DIFF
--- a/base/src/__tests__/flipbook.test.ts
+++ b/base/src/__tests__/flipbook.test.ts
@@ -592,17 +592,20 @@ describe('FlipBook', () => {
       createPages(4)
       const flipBook = new FlipBook({ pagesCount: 4 })
       flipBook.render('.flipbook-container')
+      const mockCancelAnimation = vi.fn()
       setFlipBookInternals(flipBook, {
-        currentLeaf: { index: 0 } as never,
+        currentLeaf: { index: 0, cancelAnimation: mockCancelAnimation } as never,
         flipDirection: FlipDirection.Forward,
         flipStartingPos: 50,
         isDuringAutoFlip: true,
       })
       getFlipBookInternals(flipBook).onDragStart({ center: { x: 200 } })
 
+      expect(mockCancelAnimation).toHaveBeenCalled()
       const internals = getFlipBookInternals(flipBook)
-      expect(internals.flipDirection).toBe(FlipDirection.None)
-      expect(internals.flipStartingPos).toBe(0)
+      expect(internals.isDuringAutoFlip).toBe(false)
+      expect(internals.currentLeaf).toBeUndefined()
+      expect(internals.flipStartingPos).toBe(200)
     })
 
     it('should flip forward on drag update', () => {

--- a/base/src/__tests__/leaf.test.ts
+++ b/base/src/__tests__/leaf.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FlipDirection } from '../flip-direction'
 import { FLIPPED, type FlipPosition, Leaf, NOT_FLIPPED } from '../leaf'
-import { getLeafInternals, setLeafInternals } from './test-utils'
+import { getLeafInternals } from './test-utils'
 
 describe('Leaf', () => {
   let mockPage1: HTMLElement
@@ -207,7 +207,7 @@ describe('Leaf', () => {
       vi.useRealTimers()
     })
 
-    it('should return current animation when target matches', async () => {
+    it('should resolve immediately when already at target position', async () => {
       const leaf = new Leaf(
         0,
         [mockPage1, mockPage2],
@@ -216,9 +216,8 @@ describe('Leaf', () => {
         onTurnedMock
       )
 
-      setLeafInternals(leaf, { currentAnimation: null, targetFlipPosition: 1 as FlipPosition })
-
-      const result = await leaf.flipToPosition(1 as FlipPosition)
+      // Already at position 0, requesting position 0
+      const result = await leaf.flipToPosition(0 as FlipPosition)
 
       expect(result).toBeUndefined()
     })

--- a/base/src/__tests__/test-utils.ts
+++ b/base/src/__tests__/test-utils.ts
@@ -1,13 +1,13 @@
 import type { FlipDirection } from '../flip-direction'
 import type { FlipBook } from '../flipbook'
-import type { FlipPosition, Leaf } from '../leaf'
+import type { Leaf } from '../leaf'
 
 // Type-safe test accessors for private members
 // This avoids using `any` while allowing tests to access internals
 
 interface LeafTestable {
   currentAnimation: Promise<void> | null
-  targetFlipPosition: FlipPosition | null
+  animationCancelled: boolean
 }
 
 interface MockLeaf {
@@ -51,8 +51,8 @@ export function setLeafInternals(leaf: Leaf, updates: Partial<LeafTestable>): vo
   if (updates.currentAnimation !== undefined) {
     internals.currentAnimation = updates.currentAnimation
   }
-  if (updates.targetFlipPosition !== undefined) {
-    internals.targetFlipPosition = updates.targetFlipPosition
+  if (updates.animationCancelled !== undefined) {
+    internals.animationCancelled = updates.animationCancelled
   }
 }
 

--- a/base/src/flipbook.ts
+++ b/base/src/flipbook.ts
@@ -199,7 +199,14 @@ class FlipBook {
 
   private onDragStart(event: HammerInput) {
     console.log('drag start')
-    if (this.currentLeaf || this.isDuringAutoFlip) {
+    // If there's an auto-flip in progress, cancel it and allow new flip
+    if (this.isDuringAutoFlip && this.currentLeaf) {
+      this.currentLeaf.cancelAnimation()
+      this.isDuringAutoFlip = false
+      this.currentLeaf = undefined
+    }
+    // If already dragging a leaf, don't start a new drag
+    if (this.currentLeaf) {
       this.flipDirection = FlipDirection.None
       this.flipStartingPos = 0
       return
@@ -209,7 +216,7 @@ class FlipBook {
 
   private onDragUpdate(event: HammerInput) {
     console.log('drag update')
-    if (this.isDuringAutoFlip || this.isDuringManualFlip) {
+    if (this.isDuringManualFlip) {
       return
     }
     this.isDuringManualFlip = true
@@ -270,7 +277,7 @@ class FlipBook {
 
   private async onDragEnd(event: HammerInput) {
     console.log('drag end')
-    if (!this.currentLeaf || this.isDuringAutoFlip) {
+    if (!this.currentLeaf) {
       this.flipDirection = FlipDirection.None
       this.flipStartingPos = 0
       return


### PR DESCRIPTION
Enables users to start a new flip gesture while a page flip animation is still in progress.

## Changes:
- Add `cancelAnimation()` method to Leaf class
- Add `animationCancelled` flag to interrupt running animations
- Modify drag start to cancel existing auto-flip and allow new gesture
- Remove blocking guards that prevented interaction during auto-flip

## Behavior:
- Starting a new drag gesture during an auto-flip will cancel the current animation
- The interrupted leaf stays at its current position
- New flip can begin immediately from any drag position