### PR TITLE
Fix flip continuation - keep leaf and adjust position on interrupt

### DIFF
--- a/base/src/flipbook.ts
+++ b/base/src/flipbook.ts
@@ -199,11 +199,29 @@ class FlipBook {
 
   private onDragStart(event: HammerInput) {
     console.log('drag start')
-    // If there's an auto-flip in progress, cancel it and allow new flip
+    // If there's an auto-flip in progress, cancel it and continue with same leaf
     if (this.isDuringAutoFlip && this.currentLeaf) {
       this.currentLeaf.cancelAnimation()
       this.isDuringAutoFlip = false
-      this.currentLeaf = undefined
+      // Calculate adjusted starting position based on current leaf position
+      // This makes the drag continue smoothly from where the animation was
+      const bookWidth = this.bookElement?.clientWidth ?? 0
+      const currentFlipPos = this.currentLeaf.flipPosition
+      // Adjust starting pos so that current position maps to current flip position
+      if (this.flipDirection === FlipDirection.Forward) {
+        // posForward = (flipStartingPos - currentPos) / bookWidth = currentFlipPos
+        // So: flipStartingPos = currentPos + currentFlipPos * bookWidth
+        this.flipStartingPos = this.isLTR
+          ? event.center.x + currentFlipPos * bookWidth
+          : event.center.x - currentFlipPos * bookWidth
+      } else {
+        // posBackward = 1 - |flipDelta| / bookWidth = currentFlipPos
+        // |flipDelta| = (1 - currentFlipPos) * bookWidth
+        this.flipStartingPos = this.isLTR
+          ? event.center.x - (1 - currentFlipPos) * bookWidth
+          : event.center.x + (1 - currentFlipPos) * bookWidth
+      }
+      return
     }
     // If already dragging a leaf, don't start a new drag
     if (this.currentLeaf) {


### PR DESCRIPTION
## Problem
When a user interrupts an auto-flip animation by starting a drag, the page gets stuck halfway through the flip.

## Root Cause
When cancelling the animation, `currentLeaf` was set to `undefined`, leaving the leaf in its mid-flip visual state. The new drag would then pick up a fresh leaf with position calculation starting from 0.

## Solution
- Keep `currentLeaf` instead of setting it to `undefined`
- Adjust `flipStartingPos` based on the current flip position
- This allows the user to smoothly continue dragging from the interrupted position

## Changes
- **flipbook.ts**: Modified `onDragStart` to preserve the current leaf and calculate adjusted starting position
- **flipbook.test.ts**: Updated test to verify the new behavior