### PR TITLE
fix(example): update import map to React 19

### DIFF
--- a/react/example/index.html
+++ b/react/example/index.html
@@ -8,8 +8,8 @@
     <script type="importmap">
       {
         "imports": {
-          "react": "https://esm.sh/react@18.3.1",
-          "react-dom": "https://esm.sh/react-dom@18.3.1"
+          "react": "https://esm.sh/react@19.2.3",
+          "react-dom": "https://esm.sh/react-dom@19.2.3"
         }
       }
     </script>


### PR DESCRIPTION
## Problem

The GitHub Pages site at https://doradsoft.github.io/html-flip-book/ was empty/broken due to a React version mismatch.

## Root Cause

The `index.html` import map was loading React 18.3.1 from esm.sh while `package.json` has React 19.2.3 installed. This version mismatch caused a runtime error:
```
TypeError: Cannot read properties of undefined (reading 'S')
```

## Solution

Updated the import map to load React 19.2.3 to match the installed version.