### PR TITLE
fix(cd): reset package versions to dev placeholder

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-flip-book-vanilla",
-	"version": "0.0.0-alpha.4",
+	"version": "0.0.0-dev",
 	"description": "Flipbook component for HTML (vanilla JavaScript)",
 	"author": "DoradSoft",
 	"type": "module",

--- a/react/example/package.json
+++ b/react/example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-flip-book-react-example",
-	"version": "0.0.0-alpha.4",
+	"version": "0.0.0-dev",
 	"description": "Flipbook component for HTML",
 	"homepage": "https://doradsoft.github.io/html-flip-book/",
 	"type": "module",

--- a/react/package.json
+++ b/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "html-flip-book-react",
 	"description": "Flip Book React Component",
-	"version": "0.0.0-alpha.4",
+	"version": "0.0.0-dev",
 	"type": "module",
 	"author": "DoradSoft",
 	"main": "./dist/flip-book.js",


### PR DESCRIPTION
The CD workflow failed with 'Version not changed' because the package versions matched the release tag. Package versions should use a dev placeholder that the CD workflow updates at publish time.

Fixes the publish failure from https://github.com/doradsoft/html-flip-book/actions/runs/21262100994/job/61192315475