### PR TITLE
fix(cd): add --allow-same-version to npm version commands

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Update vanilla package version
         run: |
           cd base
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Update react package version
         run: |
           cd react
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Publish vanilla package
         run: |


### PR DESCRIPTION
The CD workflow failed with 'Version not changed' because the package versions in package.json already matched the release tag. Adding `--allow-same-version` prevents this error while keeping the versioning scheme intact.

Fixes the publish failure from https://github.com/doradsoft/html-flip-book/actions/runs/21262100994/job/61192315475