### PR TITLE
docs: add TypeDoc with Read the Docs integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 .coverage
+
+# Generated documentation
+docs-dist
 *.lcov
 
 # nyc test coverage

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file for TypeDoc
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    nodejs: "22"
+  commands:
+    - npm ci
+    - npm run docs
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - cp -r docs-dist/* $READTHEDOCS_OUTPUT/html/

--- a/README.md
+++ b/README.md
@@ -1,61 +1,71 @@
 # HTML Flip Book
 
-[![Continuous Integration](https://github.com/DoradSoft/html-flip-book/actions/workflows/ci.yml/badge.svg)](https://github.com/DoradSoft/html-flip-book/actions/workflows/ci.yml?query=branch%3Amaster)
+[![CI](https://github.com/DoradSoft/html-flip-book/actions/workflows/ci.yml/badge.svg)](https://github.com/DoradSoft/html-flip-book/actions/workflows/ci.yml?query=branch%3Amaster)
+[![CD](https://github.com/DoradSoft/html-flip-book/actions/workflows/cd.yml/badge.svg)](https://github.com/DoradSoft/html-flip-book/actions/workflows/cd.yml)
 [![Codecov](https://codecov.io/gh/DoradSoft/html-flip-book/branch/master/graph/badge.svg)](https://codecov.io/gh/DoradSoft/html-flip-book)
 [![Codacy Grade](https://app.codacy.com/project/badge/Grade/87a9b9d4c81b49b8b49115c4ac7ec486)](https://app.codacy.com/gh/DoradSoft/html-flip-book/dashboard)
+[![Documentation](https://img.shields.io/badge/docs-API%20Reference-blue)](https://html-flip-book.readthedocs.io/)
+
+[![npm vanilla](https://img.shields.io/npm/v/html-flip-book-vanilla?label=vanilla)](https://www.npmjs.com/package/html-flip-book-vanilla)
+[![npm react](https://img.shields.io/npm/v/html-flip-book-react?label=react)](https://www.npmjs.com/package/html-flip-book-react)
 
 A TypeScript library for creating realistic page-flip animations in the browser.
 
+**[📖 Live Demo](https://doradsoft.github.io/html-flip-book/)** · **[📚 API Docs](https://html-flip-book.readthedocs.io/)**
+
+## Installation
+
+```bash
+# Vanilla JavaScript
+npm install html-flip-book-vanilla
+
+# React
+npm install html-flip-book-react
+```
+
 ## Features
 
-**Mandatory for production**
+### Core
 
-- [x] Horizontal flip direction - Both RTL and LTR
-- [x] Manual page flipping
-- [x] Automatic page flipping - based on velocity / based on progress
-- [x] Page flipping with mouse
-- [x] Page flipping with touch
-- [ ] Toolbar
+- **RTL & LTR Support** — Horizontal flip direction for both reading directions
+- **Touch & Mouse Input** — Drag pages with touch gestures or mouse
+- **Velocity-based Flipping** — Fast swipes complete the flip automatically
+- **Progress-based Flipping** — Partial drags complete based on progress threshold
+- **Concurrent Flip Animations** — Multiple pages can flip simultaneously
+- **Hover Effects** — Subtle inner-shadow preview on page edges
+- **Leaves Buffer** — Performance optimization for large books (only render nearby pages)
 
----
+### React Component
 
+- **Toolbar Components** — Pre-built navigation UI:
+  - `Toolbar` — Container component
+  - `PrevButton` / `NextButton` — Navigate pages
+  - `FirstPageButton` / `LastPageButton` — Jump to ends
+  - `PageIndicator` — Current page display
+  - `FullscreenButton` — Toggle fullscreen mode
+- **Imperative API** — `flipNext()`, `flipPrev()`, `goToPage()`, `jumpToPage()`
+- **Ref Handle** — Access current page index, total pages, navigation state
+
+### Examples
+
+- [Live Demo](https://doradsoft.github.io/html-flip-book/) — English (LTR) and Hebrew (RTL) books
+
+## Roadmap
+
+- [ ] Cover pages styling
 - [ ] Render on resize
-- [ ] Allow flipping during running flips
 - [ ] Internationalization
-- [ ] Animate page edges/corners
-- [ ] Curl animation
+- [ ] Curl animation / animated page edges
 - [ ] Lazy page building
 - [ ] Vertical flip direction
-- [ ] Implement Vue component
-- [ ] Implement Angular component
-- [ ] Allow scrolling of an overflowed element within page on the opposite axis
-      of the flip Examples
-
----
-
-**Madatory for production**
-
-- [x] English example
-- [ ] Hebrew example
-
----
-
-- [ ] add cover for English example
-- [ ] Complete vanilla example
-- [ ] Implement Vue example
-- [ ] Implement Angular example
+- [ ] Vue component
+- [ ] Angular component
 
 ## DevOps
 
-**Madatory for production**
-
-- [ ] Manual npm package
-
----
-
-- [ ] Documentation
-- [x] Github Actions
-- [x] Auto build and deploy to github.io
-- [ ] Auto build and deploy to npm
+- [x] GitHub Actions CI/CD
+- [x] Auto deploy to GitHub Pages
+- [x] Auto publish to npm (on release)
+- [x] API documentation (TypeDoc)
 
 ## Bugs

--- a/base/package-lock.json
+++ b/base/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "html-flip-book-vanilla",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "html-flip-book-vanilla",
-			"version": "0.0.0-alpha.16",
+			"version": "0.0.0-alpha.17",
 			"license": "MIT",
 			"dependencies": {
 				"hammerjs": "^2.0.8",

--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-flip-book-vanilla",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"description": "Flipbook component for HTML (vanilla JavaScript)",
 	"author": "DoradSoft",
 	"type": "module",

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -1,0 +1,67 @@
+# Contributing
+
+Thank you for your interest in contributing to HTML Flip Book!
+
+## Development Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/DoradSoft/html-flip-book.git
+   cd html-flip-book
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Install pre-commit hooks:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+
+4. Start development:
+   ```bash
+   npm run dev
+   ```
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Build | `npm run build` |
+| Unit Tests | `npm test` |
+| E2E Tests | `npm run test:e2e` |
+| Lint & Format | `npx biome check --write .` |
+| Generate Docs | `npm run docs` |
+
+## Guidelines
+
+- Follow the existing code style (Biome formatting)
+- Write tests for new features
+- Add JSDoc comments for public APIs (auto-generates docs)
+- Keep commits focused and descriptive
+
+## Bug Fix Workflow (Red-Green TDD)
+
+1. Write a failing test that exposes the bug
+2. Verify the test fails
+3. Fix the bug
+4. Verify the test passes
+5. Run the full test suite
+
+## Pull Requests
+
+1. Create a feature branch from `master`
+2. Make your changes
+3. Bump the version:
+   ```bash
+   cd base && npm version patch --no-git-tag-version
+   cd ../react && npm version patch --no-git-tag-version
+   ```
+4. Submit a PR
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -1,0 +1,119 @@
+# Examples
+
+## LTR Book (English)
+
+[**Live Demo →**](https://doradsoft.github.io/html-flip-book/)
+
+```tsx
+import { useRef } from 'react';
+import { FlipBook } from 'html-flip-book-react';
+import { Toolbar, PrevButton, NextButton, PageIndicator } from 'html-flip-book-react/toolbar';
+import 'html-flip-book-vanilla/style.css';
+
+function EnglishBook() {
+  const flipBookRef = useRef(null);
+
+  const pages = [
+    <div className="cover front">My Book</div>,
+    <div className="page">Chapter 1: Introduction</div>,
+    <div className="page">Lorem ipsum dolor sit amet...</div>,
+    <div className="page">Chapter 2: Getting Started</div>,
+    <div className="page">More content here...</div>,
+    <div className="cover back">The End</div>,
+  ];
+
+  return (
+    <div className="book-container">
+      <FlipBook
+        ref={flipBookRef}
+        pages={pages}
+        className="english-book"
+        direction="ltr"
+        pageSemantics={{
+          frontCover: 0,
+          backCover: pages.length - 1,
+        }}
+      />
+      <Toolbar flipBookRef={flipBookRef}>
+        <PrevButton />
+        <PageIndicator />
+        <NextButton />
+      </Toolbar>
+    </div>
+  );
+}
+```
+
+## RTL Book (Hebrew/Arabic)
+
+```tsx
+function HebrewBook() {
+  const flipBookRef = useRef(null);
+
+  const pages = [
+    <div className="cover front" dir="rtl">הספר שלי</div>,
+    <div className="page" dir="rtl">פרק א׳: הקדמה</div>,
+    <div className="page" dir="rtl">תוכן נוסף כאן...</div>,
+    <div className="cover back" dir="rtl">סוף</div>,
+  ];
+
+  return (
+    <div className="book-container" dir="rtl">
+      <FlipBook
+        ref={flipBookRef}
+        pages={pages}
+        className="hebrew-book"
+        direction="rtl"
+      />
+      <Toolbar flipBookRef={flipBookRef}>
+        <NextButton /> {/* Note: order reversed for RTL */}
+        <PageIndicator />
+        <PrevButton />
+      </Toolbar>
+    </div>
+  );
+}
+```
+
+### Key Differences for RTL
+
+1. Set `direction="rtl"` on the FlipBook
+2. Reverse toolbar button order (Next before Prev)
+3. Add `dir="rtl"` to content for proper text alignment
+
+## Styling Examples
+
+```css
+.book-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.english-book,
+.hebrew-book {
+  width: 100%;
+  max-width: 900px;
+}
+
+.cover {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.cover.front {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.page {
+  padding: 40px;
+  background: #fff;
+  font-family: Georgia, serif;
+  line-height: 1.6;
+}
+```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,93 @@
+# Getting Started
+
+## Installation
+
+```bash
+# React (includes vanilla as dependency)
+npm install html-flip-book-react
+
+# Vanilla JavaScript only
+npm install html-flip-book-vanilla
+```
+
+## Quick Start with React
+
+```tsx
+import { useRef } from 'react';
+import { FlipBook } from 'html-flip-book-react';
+import { Toolbar, PrevButton, NextButton, PageIndicator } from 'html-flip-book-react/toolbar';
+import 'html-flip-book-vanilla/style.css';
+
+function App() {
+  const flipBookRef = useRef(null);
+
+  const pages = [
+    <div className="page">Cover</div>,
+    <div className="page">Page 1</div>,
+    <div className="page">Page 2</div>,
+    <div className="page">Back Cover</div>,
+  ];
+
+  return (
+    <div>
+      <FlipBook
+        ref={flipBookRef}
+        pages={pages}
+        className="my-book"
+        direction="ltr"
+      />
+      <Toolbar flipBookRef={flipBookRef}>
+        <PrevButton />
+        <PageIndicator />
+        <NextButton />
+      </Toolbar>
+    </div>
+  );
+}
+```
+
+## Quick Start with Vanilla JavaScript
+
+```typescript
+import { FlipBook } from 'html-flip-book-vanilla';
+import 'html-flip-book-vanilla/style.css';
+
+// Create the flipbook instance
+const flipBook = new FlipBook({
+  pagesCount: 10,
+  direction: 'ltr',
+  leafAspectRatio: { width: 2, height: 3 },
+});
+
+// Render into a container
+flipBook.render('#book-container');
+
+// Programmatic navigation
+await flipBook.flipNext();
+await flipBook.flipPrev();
+await flipBook.goToPage(5);
+flipBook.jumpToPage(0); // instant, no animation
+```
+
+## Styling
+
+Import the base styles:
+
+```typescript
+import 'html-flip-book-vanilla/style.css';
+```
+
+Add your own styles:
+
+```css
+.my-book {
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 4 / 3;
+}
+
+.page {
+  padding: 20px;
+  background: white;
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "html-flip-book",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "html-flip-book",
-			"version": "0.0.0-alpha.16",
+			"version": "0.0.0-alpha.17",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {
@@ -30,6 +30,7 @@
 				"sass": "^1.97.2",
 				"semver": "^7.7.3",
 				"tsx": "^4.21.0",
+				"typedoc": "^0.28.16",
 				"typescript": "^5.9.3",
 				"vite": "^7.3.1",
 				"vite-plugin-dts": "^4.5.4",
@@ -1097,6 +1098,20 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@gerrit0/mini-shiki": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.21.0.tgz",
+			"integrity": "sha512-9PrsT5DjZA+w3lur/aOIx3FlDeHdyCEFlv9U+fmsVyjPZh61G5SYURQ/1ebe2U63KbDmI2V8IhIUegWb8hjOyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/engine-oniguruma": "^3.21.0",
+				"@shikijs/langs": "^3.21.0",
+				"@shikijs/themes": "^3.21.0",
+				"@shikijs/types": "^3.21.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@isaacs/balanced-match": {
@@ -2223,6 +2238,55 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.21.0.tgz",
+			"integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.21.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.21.0.tgz",
+			"integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.21.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.21.0.tgz",
+			"integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.21.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.21.0.tgz",
+			"integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2543,6 +2607,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "25.0.9",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
@@ -2577,6 +2651,13 @@
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
 			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2863,32 +2944,6 @@
 				}
 			}
 		},
-		"node_modules/@vue/language-core/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@vue/language-core/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@vue/shared": {
 			"version": "3.5.27",
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
@@ -2980,6 +3035,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
 		"node_modules/aria-query": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -3006,6 +3068,16 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
 		},
 		"node_modules/browserslist": {
 			"version": "4.23.0",
@@ -3961,6 +4033,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/local-pkg": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
@@ -3995,6 +4077,13 @@
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
+		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",
@@ -4068,6 +4157,31 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -4099,6 +4213,22 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mlly": {
@@ -4476,6 +4606,16 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4948,6 +5088,30 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/typedoc": {
+			"version": "0.28.16",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.16.tgz",
+			"integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@gerrit0/mini-shiki": "^3.17.0",
+				"lunr": "^2.3.9",
+				"markdown-it": "^14.1.0",
+				"minimatch": "^9.0.5",
+				"yaml": "^2.8.1"
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 18",
+				"pnpm": ">= 10"
+			},
+			"peerDependencies": {
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4961,6 +5125,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ufo": {
 			"version": "1.6.3",
@@ -5294,6 +5465,22 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-flip-book",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"description": "Flipbook component for HTML",
 	"homepage": "https://doradsoft.github.io/html-flip-book/",
 	"repository": {
@@ -37,6 +37,7 @@
 		"check": "biome check .",
 		"ci-test": "vitest run --coverage && playwright test && npm run coverage:merge",
 		"all": "npm run check && npm run test:coverage && npm run build",
+		"docs": "typedoc",
 		"release": "tsx scripts/release.mts",
 		"release:patch": "tsx scripts/release.mts patch",
 		"release:minor": "tsx scripts/release.mts minor",
@@ -65,6 +66,7 @@
 		"sass": "^1.97.2",
 		"semver": "^7.7.3",
 		"tsx": "^4.21.0",
+		"typedoc": "^0.28.16",
 		"typescript": "^5.9.3",
 		"vite": "^7.3.1",
 		"vite-plugin-dts": "^4.5.4",

--- a/react/example/package-lock.json
+++ b/react/example/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "html-flip-book-react-example",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "html-flip-book-react-example",
-			"version": "0.0.0-alpha.16",
+			"version": "0.0.0-alpha.17",
 			"license": "MIT",
 			"dependencies": {
 				"html-flip-book-react": "0.0.0-alpha.1",

--- a/react/example/package.json
+++ b/react/example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-flip-book-react-example",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"description": "Flipbook component for HTML",
 	"homepage": "https://doradsoft.github.io/html-flip-book/",
 	"type": "module",

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "html-flip-book-react",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "html-flip-book-react",
-			"version": "0.0.0-alpha.16",
+			"version": "0.0.0-alpha.17",
 			"license": "MIT",
 			"dependencies": {
 				"html-flip-book-vanilla": "file:../base"

--- a/react/package.json
+++ b/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "html-flip-book-react",
 	"description": "Flip Book React Component",
-	"version": "0.0.0-alpha.16",
+	"version": "0.0.0-alpha.17",
 	"type": "module",
 	"author": "DoradSoft",
 	"main": "./dist/flip-book.js",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": [
+		"./base/src/flipbook.ts",
+		"./react/src/FlipBook.tsx",
+		"./react/src/toolbar/index.ts"
+	],
+	"out": "./docs-dist",
+	"name": "HTML Flip Book",
+	"readme": "./README.md",
+	"includeVersion": true,
+	"categorizeByGroup": true,
+	"navigationLinks": {
+		"Demo": "https://doradsoft.github.io/html-flip-book/",
+		"GitHub": "https://github.com/DoradSoft/html-flip-book"
+	},
+	"projectDocuments": ["./docs/guides/*.md"],
+	"exclude": ["**/__tests__/**", "**/node_modules/**"],
+	"excludePrivate": true,
+	"excludeProtected": true,
+	"skipErrorChecking": true
+}


### PR DESCRIPTION
- Add typedoc.json configuration with entry points for base, react, and toolbar
- Add manual guide pages (getting-started, examples, contributing)
- Add .readthedocs.yaml for automated documentation builds
- Update README with proper feature documentation and live demo link
- Add npm run docs script
- Bump version to 0.0.0-alpha.17